### PR TITLE
refactor: 대시보드 상세 레이아웃 반응형 개선

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -93,18 +93,18 @@ const buttonVariants = cva(
 
         /**
          * 새 컬럼 추가 버튼 — 반응형
-         * mobile: 284×66 | tablet(md): 544×70 | desktop(lg): 354×70
+         * mobile: 284×66 | tablet(md) ~ desktop(lg): 354×70
          * font: mobile 16px bold → tablet/desktop 18px bold
          */
         add_column:
-          'w-[284px] h-[66px] rounded-[8px] md:w-[544px] md:h-[70px] lg:w-[354px] lg:h-[70px] text-lg-bold md:text-2lg-bold gap-3',
+          'w-[284px] h-[66px] rounded-[8px] md:w-[354px] md:h-[70px] text-lg-bold md:text-2lg-bold gap-3',
 
         /**
          * 할 일 추가(+) 버튼 — 반응형
-         * mobile: 284×32 | tablet(md): 544×40 | desktop(lg): 314×40
+         * mobile: 284×32 | tablet(md)~desktop(lg): 314×40 (column 354 - px-5 20×2)
          */
         add_todo:
-          'w-[284px] h-[32px] rounded-[8px] md:w-[544px] md:h-[40px] lg:w-[314px] lg:h-[40px] text-md-medium gap-3',
+          'w-[284px] h-[32px] rounded-[8px] md:w-[314px] md:h-[40px] text-md-medium gap-3',
 
         /**
          * 대시보드 카드 버튼 — 반응형

--- a/src/components/dashboard/Column.tsx
+++ b/src/components/dashboard/Column.tsx
@@ -59,9 +59,9 @@ export default function Column({
     <div
       className={[
         'flex flex-col shrink-0',
-        'w-[284px] md:w-[544px] lg:w-[354px]',
-        'border-b md:border-b-0 md:border-r border-gray-200',
-        'pb-4 md:pb-0',
+        'w-full lg:w-[354px]',
+        'border-b lg:border-b-0 lg:border-r border-gray-200',
+        'pb-4 lg:pb-0',
       ].join(' ')}
     >
       {/* ── 컬럼 헤더 ── */}
@@ -95,6 +95,7 @@ export default function Column({
           variant="secondary"
           size="add_todo"
           onClick={() => onAddCard(column.id)}
+          className="w-full md:w-full lg:w-[314px]"
           aria-label="할 일 추가"
         >
           <span className="w-4 h-4 flex items-center justify-center rounded bg-brand-violet-light text-brand-violet text-lg-bold leading-none">

--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -161,6 +161,15 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
               관리
             </Link>
           )}
+          {dashboard.createdByMe && (
+            <Link
+              href={`/dashboard/${dashboardId}/edit`}
+              className="flex md:hidden w-8 h-8 items-center justify-center rounded-md border border-gray-300 text-gray-600 hover:bg-gray-100 transition-colors"
+              aria-label="대시보드 관리"
+            >
+              <SettingIcon width={16} height={16} />
+            </Link>
+          )}
 
           <button
             type="button"
@@ -169,6 +178,14 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
           >
             <AddBoxIcon width={16} height={16} />
             초대하기
+          </button>
+          <button
+            type="button"
+            onClick={handleInvite}
+            className="flex md:hidden w-8 h-8 items-center justify-center rounded-md border border-gray-300 text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="초대하기"
+          >
+            <AddBoxIcon width={16} height={16} />
           </button>
 
           {/* 멤버 아바타 (최대 4명 + 초과 수) */}
@@ -219,7 +236,7 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
 
       {/* ── 칸반 보드 ── */}
       <div className="flex-1 overflow-hidden bg-gray-100">
-        <div className="flex flex-col md:flex-row h-full overflow-y-auto md:overflow-y-hidden md:overflow-x-auto">
+        <div className="flex flex-col lg:flex-row h-full overflow-y-auto lg:overflow-y-hidden lg:overflow-x-auto">
           {columns.map((column, index) => (
             <Column
               key={column.id}
@@ -235,11 +252,12 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
           ))}
 
           {/* 새로운 컬럼 추가하기 */}
-          <div className="flex items-start pt-[64px] px-4 md:px-5 shrink-0">
+          <div className="flex items-start pt-4 lg:pt-[64px] px-4 md:px-5 pb-8 lg:pb-0 shrink-0">
             <Button
               variant="secondary"
               size="add_column"
               onClick={handleAddColumn}
+              className="w-full md:w-full lg:w-[354px]"
             >
               새로운 컬럼 추가하기
               <span className="w-5 h-5 flex items-center justify-center rounded bg-brand-violet-light text-brand-violet text-lg-bold leading-none">

--- a/src/components/layout/SideMenu/SideMenu.tsx
+++ b/src/components/layout/SideMenu/SideMenu.tsx
@@ -73,13 +73,13 @@ const SideMenu = () => {
     <aside
       className={cn(
         'flex flex-col shrink-0 bg-white border-r border-gray-200 min-h-screen',
-        'w-[67px] md:w-[160px] xl:w-[300px]',
+        'w-[67px] md:w-[160px] lg:w-[300px]',
       )}
     >
       {/* ── 로고 ── */}
       <Link
         href="/"
-        className="flex items-center shrink-0 pt-5 pl-[22px] md:pt-5 md:pl-[13px] xl:pl-2 mb-[39px] md:mb-[57px] xl:mb-14"
+        className="flex items-center shrink-0 pt-5 pl-[22px] md:pt-5 md:pl-[13px] lg:pl-2 mb-[39px] md:mb-[57px] lg:mb-14"
       >
         <span className="md:hidden">
           <Logo variant="small" />
@@ -90,7 +90,7 @@ const SideMenu = () => {
       </Link>
 
       {/* ── Dash Boards 영역 ── */}
-      <div className="flex items-center justify-between shrink-0 pl-6 pr-[14px] md:pl-[13px] md:pr-[13px] xl:pl-2 xl:pr-3 mb-[18px] md:mb-4">
+      <div className="flex items-center justify-between shrink-0 pl-6 pr-[14px] md:pl-[13px] md:pr-[13px] lg:pl-2 lg:pr-3 mb-[18px] md:mb-4">
         <span className="hidden md:block text-xs-semibold text-gray-500">
           Dash Boards
         </span>
@@ -106,7 +106,7 @@ const SideMenu = () => {
 
       {/* ── 대시보드 목록 ── */}
       <div className="flex-1 overflow-y-auto">
-        <ul className="flex flex-col gap-1.5 md:gap-0.5 xl:gap-2">
+        <ul className="flex flex-col gap-1.5 md:gap-0.5 lg:gap-2">
           {pagedDashboards.map((dashboard) => {
             const isActive =
               pathname === `/dashboard/${dashboard.id}` ||
@@ -132,7 +132,7 @@ const SideMenu = () => {
                   {/* tablet: [dot] gap-4 [text + crown(gap-1.5)] */}
                   <div
                     className={cn(
-                      'hidden md:flex xl:hidden items-center gap-4',
+                      'hidden md:flex lg:hidden items-center gap-4',
                       'h-[43px] mx-2 px-[10px] rounded-[4px] transition-colors',
                       isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
                     )}
@@ -163,7 +163,7 @@ const SideMenu = () => {
                   {/* desktop: [dot] gap-4 [text + crown(gap-1.5)] */}
                   <div
                     className={cn(
-                      'hidden xl:flex items-center gap-4',
+                      'hidden lg:flex items-center gap-4',
                       'h-[50px] mx-3 px-3 rounded-[4px] transition-colors',
                       isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
                     )}
@@ -199,7 +199,7 @@ const SideMenu = () => {
 
       {/* ── 페이지네이션 (tablet/desktop만 표시, 15개 초과 시에만 렌더링) ── */}
       {totalPages > 1 && (
-        <div className="hidden md:flex items-center gap-3 shrink-0 px-5 pt-6 xl:pt-8 pb-4">
+        <div className="hidden md:flex items-center gap-3 shrink-0 px-5 pt-6 lg:pt-8 pb-4">
           <Pagination
             size="sm"
             currentPage={page}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [ ] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [x] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- 사이드바 데스크탑 전환: `xl` (1280px) → `lg` (1024px)
- 모바일/태블릿에서 컬럼 너비를 전체 너비로 변경
- 모바일/태블릿에서 `+` 버튼이 카드와 너비가 다르게 보이던 문제 수정
- '새로운 컬럼 추가하기' 버튼에 하단 여백 추가

## 📸 스크린샷 (UI 변경 시 권장)

| 변경 전 | 변경 후 |
| ------- | ------- |
|         |         |
스크린샷 찍기 깜빡 이슈 ..

## 🔗 관련 이슈

- Resolves #28 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?
