### PR TITLE
feat: SideMenu 대시보드 목록 API연동

### DIFF
--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -7,10 +7,22 @@
 import api from './axios';
 import type {
   Dashboard,
+  DashboardsResponse,
   ColumnsResponse,
   CardsResponse,
   MembersResponse,
 } from '@/types/dashboard';
+
+/** 대시보드 목록 조회 (사이드 네비게이션용, 페이지 기반) */
+export async function getDashboards(
+  page = 1,
+  size = 15,
+): Promise<DashboardsResponse> {
+  const { data } = await api.get<DashboardsResponse>('/dashboards', {
+    params: { navigationMethod: 'pagination', page, size },
+  });
+  return data;
+}
 
 /** 대시보드 단건 조회 */
 export async function getDashboard(dashboardId: number): Promise<Dashboard> {

--- a/src/components/common/Icon/CrownIcon.tsx
+++ b/src/components/common/Icon/CrownIcon.tsx
@@ -10,6 +10,8 @@ import { SVGProps } from 'react';
 export default function CrownIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
+      width={18}
+      height={14}
       viewBox="0 0 18 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -17,6 +17,7 @@ import type { Column as ColumnType, Card } from '@/types/dashboard';
 import {
   getDashboard,
   getColumns,
+  getMembers,
   getCards,
   createColumn,
   updateColumn,
@@ -38,6 +39,8 @@ interface ColumnCardState {
   totalCount: number;
   cursorId: number | null;
 }
+
+const MAX_VISIBLE_MEMBERS = 4;
 
 export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
   const [columnCards, setColumnCards] = useState<
@@ -93,7 +96,15 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
     enabled: !!columnsData?.data?.length,
   });
 
+  const { data: membersData } = useQuery({
+    queryKey: QUERY_KEYS.members(dashboardId),
+    queryFn: () => getMembers(dashboardId),
+  });
+
   const columns = columnsData?.data ?? [];
+  const members = membersData?.members ?? [];
+  const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS);
+  const extraMemberCount = Math.max(0, members.length - MAX_VISIBLE_MEMBERS);
 
   // ── 이벤트 핸들러 ──
 

--- a/src/components/layout/SideMenu/SideMenu.tsx
+++ b/src/components/layout/SideMenu/SideMenu.tsx
@@ -14,56 +14,29 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 import AddBoxIcon from '@/components/common/Icon/AddBoxIcon';
 import CrownIcon from '@/components/common/Icon/CrownIcon';
 import Pagination from '@/components/common/Pagination/Pagination';
 import Logo from '@/components/common/Logo';
 import { cn } from '@/lib/utils';
-
-interface Dashboard {
-  id: number;
-  /** 대시보드 이름 */
-  title: string;
-  /** 컬러칩과 매핑된 hex 코드 색상값 */
-  color: string;
-  /** 내가 만든 대시보드 여부 (true면 왕관 아이콘 표시) */
-  createdByMe: boolean;
-}
-
-// TODO: [하늘] API 연동 후 props 혹은 커스텀 훅으로 변경
-const MOCK_DASHBOARDS: Dashboard[] = [
-  { id: 1, title: '비브리지', color: '#7AC555', createdByMe: true },
-  { id: 2, title: '코드잇', color: '#760DDE', createdByMe: true },
-  { id: 3, title: '3분기 계획', color: '#FFA500', createdByMe: false },
-  { id: 4, title: '회의록', color: '#76A5EA', createdByMe: false },
-  { id: 5, title: '중요 문서함', color: '#E876EA', createdByMe: false },
-  { id: 6, title: '비브리지', color: '#7AC555', createdByMe: true },
-  { id: 7, title: '코드잇', color: '#760DDE', createdByMe: true },
-  { id: 8, title: '3분기 계획', color: '#FFA500', createdByMe: false },
-  { id: 9, title: '회의록', color: '#76A5EA', createdByMe: false },
-  { id: 10, title: '중요 문서함', color: '#E876EA', createdByMe: false },
-  { id: 11, title: '회의록', color: '#76A5EA', createdByMe: false },
-  { id: 12, title: '비브리지', color: '#7AC555', createdByMe: true },
-  { id: 13, title: '코드잇', color: '#760DDE', createdByMe: true },
-  { id: 14, title: '3분기 계획', color: '#FFA500', createdByMe: false },
-  { id: 15, title: '회의록', color: '#76A5EA', createdByMe: false },
-  { id: 16, title: '중요 문서함', color: '#E876EA', createdByMe: false },
-];
+import { getDashboards } from '@/api/dashboard';
+import { QUERY_KEYS } from '@/constants/queryKeys';
 
 const PAGE_SIZE = 15;
-
-// 메인 컴포넌트
 
 const SideMenu = () => {
   const pathname = usePathname();
   const [page, setPage] = useState(1);
 
-  const totalCount = MOCK_DASHBOARDS.length;
+  const { data } = useQuery({
+    queryKey: [...QUERY_KEYS.dashboards(), page],
+    queryFn: () => getDashboards(page, PAGE_SIZE),
+  });
+
+  const dashboards = data?.dashboards ?? [];
+  const totalCount = data?.totalCount ?? 0;
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
-  const pagedDashboards = MOCK_DASHBOARDS.slice(
-    (page - 1) * PAGE_SIZE,
-    page * PAGE_SIZE,
-  );
 
   const handlePrevPage = () => setPage((prev) => Math.max(1, prev - 1));
   const handleNextPage = () =>
@@ -107,7 +80,7 @@ const SideMenu = () => {
       {/* ── 대시보드 목록 ── */}
       <div className="flex-1 overflow-y-auto">
         <ul className="flex flex-col gap-1.5 md:gap-0.5 lg:gap-2">
-          {pagedDashboards.map((dashboard) => {
+          {dashboards.map((dashboard) => {
             const isActive =
               pathname === `/dashboard/${dashboard.id}` ||
               pathname.startsWith(`/dashboard/${dashboard.id}/`);

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -79,3 +79,10 @@ export interface MembersResponse {
   members: Member[];
   totalCount: number;
 }
+
+/** GET /dashboards 응답 */
+export interface DashboardsResponse {
+  cursorId: number | null;
+  totalCount: number;
+  dashboards: Dashboard[];
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [x] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용
- [GET /dashboards?navigationMethod=pagination] API 연동으로 사이드바 대시보드 목록 실제 데이터 표시
- [getDashboards(page, size)] API 함수 추가 (api/dashboard.ts)
- [DashboardsResponse] 타입 추가 (types/dashboard.ts)
- SideMenu 목업 데이터 제거 및 React Query 연결

## 📸 스크린샷 (UI 변경 시 권장)

| 변경 전 | 변경 후 |
| ------- | ------- |
|     
<img width="831" height="637" alt="image" src="https://github.com/user-attachments/assets/66c6f69b-3476-436e-b9f7-f7eb57f12221" />
    |    
<img width="791" height="589" alt="image" src="https://github.com/user-attachments/assets/456c2934-0638-4815-9fa9-c1d62523d405" />
     |

## 🔗 관련 이슈

- Resolves #50 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?
