### PR TITLE
feat: 공용 Button/Input 기반 모달(Alert, Confirm, Form) 컴포넌트 구현 및 UI 정리

### DIFF
--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -19,7 +19,7 @@
  */
 
 import ModalBase from '@/components/common/ModalBase';
-import Button from '../common/Button';
+import Button from '@/components/common/Button';
 
 interface AlertModalProps {
   message: string;

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -19,6 +19,7 @@
  */
 
 import ModalBase from '@/components/common/ModalBase';
+import Button from '../common/Button';
 
 interface AlertModalProps {
   message: string;
@@ -33,16 +34,18 @@ export default function AlertModal({
 }: AlertModalProps) {
   return (
     <ModalBase className="w-[368px] rounded-[16px] px-[64px] py-[40px]">
-      <p className="mb-[14px] text-center text-[18px] font-medium text-[#333236]">
+      <p className="mb-[14px] text-center text-2lg-medium text-gray-700">
         {message}
       </p>
 
-      <button
+      <Button
+        variant="primary"
+        size="modal_lg"
         onClick={onConfirm}
-        className="w-[240px] h-[48px] rounded-[8px] bg-[#5534DA] px-[46px] py-[14px] text-[16px] font-semibold text-white hover:bg-[#4C32D1]"
+        className="mx-auto w-[240px]"
       >
         {buttonText}
-      </button>
+      </Button>
     </ModalBase>
   );
 }

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -22,6 +22,7 @@
  */
 
 import ModalBase from '@/components/common/ModalBase';
+import Button from '../common/Button';
 
 interface ConfirmModalProps {
   message: string;
@@ -40,24 +41,28 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <ModalBase className="w-[568px] rounded-[16px] p-[24px]">
-      <p className="mb-[24px] text-center text-[20px] font-medium text-[#333236]">
+      <p className="mb-[24px] text-center text-xl-medium text-gray-700">
         {message}
       </p>
 
       <div className="flex gap-[14px]">
-        <button
+        <Button
+          variant="secondary"
+          size="modal_lg"
           onClick={onCancel}
-          className="flex-1 rounded-[8px] border border-[#D9D9D9] bg-white py-[14px] text-[16px] font-medium text-[#787486]"
+          className="flex-1"
         >
           {cancelText}
-        </button>
+        </Button>
 
-        <button
+        <Button
+          variant="primary"
+          size="modal_lg"
           onClick={onConfirm}
-          className="flex-1 rounded-[8px] bg-[#5534DA] py-[14px] text-[16px] font-semibold text-white hover:bg-[#4C32D1]"
+          className="flex-1"
         >
           {confirmText}
-        </button>
+        </Button>
       </div>
     </ModalBase>
   );

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -22,7 +22,7 @@
  */
 
 import ModalBase from '@/components/common/ModalBase';
-import Button from '../common/Button';
+import Button from '@/components/common/Button';
 
 interface ConfirmModalProps {
   message: string;

--- a/src/components/Modal/FormModal.tsx
+++ b/src/components/Modal/FormModal.tsx
@@ -33,7 +33,7 @@
 import ModalBase from '@/components/common/ModalBase';
 import XIcon from '@/components/common/Icon/XIcon';
 import { Input } from '@/components/common/Input';
-import Button from '../common/Button';
+import Button from '@/components/common/Button';
 
 interface FormModalProps {
   title: string;

--- a/src/components/Modal/FormModal.tsx
+++ b/src/components/Modal/FormModal.tsx
@@ -31,7 +31,9 @@
  */
 
 import ModalBase from '@/components/common/ModalBase';
-import XIcon from '@/components/common/Icon/XIcon'; // 경로 맞게 수정
+import XIcon from '@/components/common/Icon/XIcon';
+import { Input } from '@/components/common/Input';
+import Button from '../common/Button';
 
 interface FormModalProps {
   title: string;
@@ -67,7 +69,7 @@ export default function FormModal({
   return (
     <ModalBase className="w-[568px] rounded-[8px] p-[24px]">
       <div className="mb-[24px] flex items-start justify-between">
-        <h2 className="text-[24px] font-bold text-[#333333]">{title}</h2>
+        <h2 className="text-2xl-bold text-gray-900">{title}</h2>
 
         {showCloseButton && (
           <button
@@ -81,41 +83,38 @@ export default function FormModal({
       </div>
 
       <div className="mb-[10px]">
-        <label className="mb-[8px] block text-[18px] font-medium text-[#333236]">
+        <label className="mb-[8px] block text-2lg-medium text-gray-700">
           {label}
         </label>
 
-        <input
+        <Input
           value={value}
-          onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className={`w-full rounded-[8px] border px-[16px] py-[15px] text-[16px] text-[#333236] outline-none bg-white ${
-            errorText ? 'border-[#D6173A]' : 'border-[#D9D9D9]'
-          }`}
+          onChange={(e) => onChange(e.target.value)}
+          isError={!!errorText}
+          errorMessage={errorText}
         />
-
-        {errorText && (
-          <p className="mt-[8px] text-[14px] text-[#D6173A]">{errorText}</p>
-        )}
       </div>
 
-      <div className="mt-[20px] flex gap-[10px]">
-        <button
-          type="button"
+      <div className="mt-[20px] flex gap-[14px]">
+        <Button
+          variant="secondary"
+          size="modal_lg"
           onClick={onCancel}
-          className="flex-1 rounded-[8px] border border-[#D9D9D9] bg-white py-[14px] text-[18px] font-medium text-[#9A9A9A]"
+          className="flex-1"
         >
           {cancelText}
-        </button>
+        </Button>
 
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="modal_lg"
           onClick={onConfirm}
           disabled={confirmDisabled}
-          className="flex-1 rounded-[8px] bg-[#5534DA] py-[16px] text-[18px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex-1"
         >
           {confirmText}
-        </button>
+        </Button>
       </div>
     </ModalBase>
   );


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [X] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [X] 🔧 리팩토링
- [X] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- modal 내부 버튼을 공용 Button 컴포넌트로 교체
- modal 입력 필드를 공용 Input 컴포넌트로 교체
- ConfirmModal 버튼 레이아웃을 flex 기반으로 수정 (버튼 1:1 비율)
- AlertModal 버튼은 디자인에 맞게 width override 적용
- FormModal에서 공용 Input 사용 시 label 크기 차이로 인해 label을 외부로 분리하여 UI 보정
- Tailwind 색상 및 폰트 토큰 기반으로 스타일 통일

## 📸 스크린샷 (UI 변경 시 권장)

| 변경 전 | 변경 후 |
| ------- | ------- |
|         |         |

## 🔗 관련 이슈

- Resolves #53 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [X] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [X] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [X] 불필요한 `console.log`나 주석을 지웠나요?
- [X] (선택) 리뷰어가 특별히 확인해 주었으면 하는 부분이 있나요?

- 공용 Input의 label 스타일과 피그마 디자인 간 차이가 있어 FormModal에서는 label을 외부로 분리하여 처리했습니다.
- Button 컴포넌트는 공용 스타일을 유지하면서 모달 레이아웃에 맞게 일부 width를 override하여 적용했습니다.