### PR TITLE
feat: 헤더 기능 구현 및 대시보드 상태관리 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "19.2.3",
         "react-datepicker": "^9.1.0",
         "react-dom": "19.2.3",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1393,7 +1394,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2763,7 +2764,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7409,6 +7410,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "19.2.3",
     "react-datepicker": "^9.1.0",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zustand": "^5.0.12"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": [

--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -11,8 +11,9 @@
  *   현재는 localStorage 토큰 방식이라 클라이언트에서 전부 로드합니다.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useDashboardStore } from '@/store/useDashboardStore';
 import type { Column as ColumnType, Card } from '@/types/dashboard';
 import {
   getDashboard,
@@ -65,6 +66,11 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
   const [deleteColumnId, setDeleteColumnId] = useState<number | null>(null);
 
   const queryClient = useQueryClient();
+  const setActiveDashboardId = useDashboardStore((s) => s.setActiveDashboardId);
+
+  useEffect(() => {
+    setActiveDashboardId(dashboardId);
+  }, [dashboardId, setActiveDashboardId]);
 
   const { data: dashboard, isLoading: isDashboardLoading } = useQuery({
     queryKey: QUERY_KEYS.dashboard(dashboardId),

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -4,7 +4,7 @@
  * @file Header.tsx
  * @description 서비스 상단에 고정되는 공통 헤더(GNB) 컴포넌트입니다.
  * 현재 선택된 대시보드의 타이틀, 참여 멤버 프로필 칩, 내 프로필을 표시합니다.
- * @author 승미
+ * @author 승미, 하늘
  * * @notes
  * - 접속한 라우트 경로(pathname)에 따라 우측 버튼('관리', '초대하기') 노출 여부가 달라집니다.
  * - 내 정보 및 알림 드롭다운 조작을 위해 'use client'가 선언되어 있습니다.
@@ -12,39 +12,89 @@
 
 'use client';
 
+import { useParams, useRouter, usePathname } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
 import CrownIcon from '@/components/common/Icon/CrownIcon';
 import AddBoxIcon from '@/components/common/Icon/AddBoxIcon';
 import SettingIcon from '@/components/common/Icon/SettingIcon';
+import { getDashboard, getMembers } from '@/api/dashboard';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useDashboardStore } from '@/store/useDashboardStore';
 
-type Member = {
-  id: number;
-  name: string;
-  bgColor: string;
-};
+const MAX_VISIBLE_MEMBERS = 4;
 
-const members: Member[] = [
-  { id: 1, name: 'Y', bgColor: 'bg-[#FFC85A]' },
-  { id: 2, name: 'C', bgColor: 'bg-[#FDD446]' },
-  { id: 3, name: 'K', bgColor: 'bg-[#9DD7ED]' },
-  { id: 4, name: 'J', bgColor: 'bg-[#C4B1A2]' },
+/** 프로필 이미지 없을 때 순서에 따라 순환하는 배경색 */
+const CHIP_COLORS = [
+  '#FFC85A',
+  '#FDD446',
+  '#9DD7ED',
+  '#C4B1A2',
+  '#A3C4A2',
+  '#C4A3BD',
 ];
 
 export default function Header() {
+  const params = useParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const activeDashboardId = useDashboardStore((s) => s.activeDashboardId);
+
+  const PAGE_TITLES: Record<string, string> = {
+    '/mydashboard': '내 대시보드',
+    '/mypage': '계정관리',
+  };
+  const staticTitle = PAGE_TITLES[pathname] ?? null;
+
+  const dashboardId = params?.id ? Number(params.id) : null;
+
+  /** URL에 id가 없으면 스토어의 마지막 방문 대시보드 사용 */
+  const effectiveDashboardId = dashboardId ?? activeDashboardId;
+
+  const { data: dashboard } = useQuery({
+    queryKey: QUERY_KEYS.dashboard(effectiveDashboardId!),
+    queryFn: () => getDashboard(effectiveDashboardId!),
+    enabled: !!effectiveDashboardId,
+  });
+
+  const { data: membersData } = useQuery({
+    queryKey: QUERY_KEYS.members(effectiveDashboardId!),
+    queryFn: () => getMembers(effectiveDashboardId!),
+    enabled: !!effectiveDashboardId,
+  });
+
+  const members = membersData?.members ?? [];
+  const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS);
+  const extraCount = Math.max(0, members.length - MAX_VISIBLE_MEMBERS);
+
+  const handleManageClick = () => {
+    if (dashboardId) {
+      router.push(`/dashboard/${dashboardId}/edit`);
+    }
+  };
+
   return (
     <header className="flex h-[64px] w-full items-center justify-between shrink-0 border-b border-gray-200 bg-white px-8">
       <div className="flex min-w-0 items-center gap-2">
-        <h1 className="truncate text-xl-bold text-gray-700">비브리지</h1>
-        <CrownIcon className="h-[20px] w-[16px] shrink-0" />
+        <h1 className="hidden lg:block truncate text-xl-bold text-gray-700">
+          {staticTitle ?? dashboard?.title ?? ''}
+        </h1>
+        {!staticTitle && dashboard?.createdByMe && (
+          <CrownIcon className="hidden lg:block h-[20px] w-[16px] shrink-0" />
+        )}
       </div>
 
       <div className="flex shrink-0 items-center gap-4">
-        <button
-          type="button"
-          className="flex h-[40px] items-center gap-2 rounded-[8px] border border-gray-300 bg-white px-4 text-md-medium text-gray-500"
-        >
-          <SettingIcon className="h-[20px] w-[20px]" />
-          관리
-        </button>
+        {dashboard?.createdByMe && (
+          <button
+            type="button"
+            onClick={handleManageClick}
+            className="flex h-[40px] items-center gap-2 rounded-[8px] border border-gray-300 bg-white px-4 text-md-medium text-gray-500"
+          >
+            <SettingIcon className="h-[20px] w-[20px]" />
+            관리
+          </button>
+        )}
 
         <button
           type="button"
@@ -54,37 +104,57 @@ export default function Header() {
           초대하기
         </button>
 
-        <div className="ml-1 flex items-center">
-          <div className="flex items-center">
-            {members.map((member, index) => (
-              <div
-                key={member.id}
-                className={`relative flex h-[38px] w-[38px] items-center justify-center rounded-full border-2 border-white text-md-semibold text-white ${member.bgColor} ${
-                  index !== 0 ? '-ml-2' : ''
-                }`}
-                style={{
-                  zIndex: index + 1,
-                }}
-                title={member.name}
-              >
-                {member.name}
-              </div>
-            ))}
+        <div className="ml-1 flex items-center gap-0">
+          {visibleMembers.length > 0 && (
+            <div className="flex items-center">
+              {visibleMembers.map((member, index) => (
+                <div
+                  key={member.id}
+                  className="relative flex h-[38px] w-[38px] items-center justify-center rounded-full border-2 border-white text-md-semibold text-white overflow-hidden"
+                  style={{
+                    backgroundColor: member.profileImageUrl
+                      ? undefined
+                      : CHIP_COLORS[index % CHIP_COLORS.length],
+                    marginLeft: index !== 0 ? '-8px' : undefined,
+                    zIndex: index + 1,
+                  }}
+                  title={member.nickname}
+                >
+                  {member.profileImageUrl ? (
+                    <Image
+                      src={member.profileImageUrl}
+                      alt={member.nickname}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  ) : (
+                    member.nickname[0].toUpperCase()
+                  )}
+                </div>
+              ))}
 
-            <div
-              className="-ml-2 flex h-[38px] min-w-[38px] items-center justify-center rounded-full border-2 border-white bg-[#F4D7DA] px-[8px] text-xs-semibold text-[#D25B68]"
-              style={{ zIndex: members.length + 1 }}
-            >
-              +2
+              {extraCount > 0 && (
+                <div
+                  className="-ml-2 flex h-[38px] min-w-[38px] items-center justify-center rounded-full border-2 border-white bg-[#F4D7DA] px-[8px] text-xs-semibold text-[#D25B68]"
+                  style={{ zIndex: visibleMembers.length + 1 }}
+                >
+                  +{extraCount}
+                </div>
+              )}
             </div>
-          </div>
+          )}
 
-          <div className="ml-6 flex items-center gap-3 border-l border-gray-300 pl-6">
+          <button
+            type="button"
+            onClick={() => router.push('/mypage')}
+            className="ml-6 flex items-center gap-3 border-l border-gray-300 pl-6 hover:opacity-80 transition-opacity"
+          >
             <div className="flex h-[38px] w-[38px] items-center justify-center rounded-full bg-[#A3C4A2] text-lg-medium text-white">
               B
             </div>
             <span className="text-lg-medium text-gray-700">배유철</span>
-          </div>
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/layout/SideMenu/SideMenu.tsx
+++ b/src/components/layout/SideMenu/SideMenu.tsx
@@ -51,7 +51,7 @@ const SideMenu = () => {
     >
       {/* ── 로고 ── */}
       <Link
-        href="/"
+        href={pathname === '/mydashboard' ? '/' : '/mydashboard'}
         className="flex items-center shrink-0 pt-5 pl-[22px] md:pt-5 md:pl-[13px] lg:pl-2 mb-[39px] md:mb-[57px] lg:mb-14"
       >
         <span className="md:hidden">

--- a/src/store/useDashboardStore.ts
+++ b/src/store/useDashboardStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+interface DashboardStore {
+  /** 마지막으로 방문한 대시보드 ID (헤더 멤버 칩에 사용) */
+  activeDashboardId: number | null;
+  setActiveDashboardId: (id: number) => void;
+}
+
+export const useDashboardStore = create<DashboardStore>((set) => ({
+  activeDashboardId: null,
+  setActiveDashboardId: (id) => set({ activeDashboardId: id }),
+}));


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [x] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [x] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [x] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- createByMe 조건으로 내가 만든 대시보드에만 헤더에 왕관 아이콘 API연동
- 내가 만든 대시보드일 경우 관리 버튼 표시, /edit 라우팅 연결
- 멤버 API데이터로 프로필 렌더링 (4명 초과 시 +N 표시)
- 태블릿/모바일에서 헤더 타이틀 숨김 처리
- 페이지별 헤더 타이틀 적용 (내 대시보드, 대시보드 이름, 계정관리)
- 프로필 영역 클릭 시 /mypage 이동 
- 대시보드 상세에서 로고 클릭 시 /mydashboard 이동 (내 대시보드에서는 로고 클릭 시 / 이동)
- zustand 라이브러리 추가 (dashboardid 전역 상태관리 위함, Figma 시안 내 mypage에서도 대시보드 멤버 칩 표시가 되어있음)  



## 🔗 관련 이슈

- Resolves #65 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?