### PR TITLE
fix: 대시보드 상세 재방문 시 카드 목록이 표시되지 않는 문제 수정

### DIFF
--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -45,9 +45,6 @@ interface ColumnCardState {
 const MAX_VISIBLE_MEMBERS = 4;
 
 export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
-  const [columnCards, setColumnCards] = useState<
-    Record<number, ColumnCardState>
-  >({});
   const [isCardModalOpen, setIsCardModalOpen] = useState(false);
   const [createCardColumnId, setCreateCardColumnId] = useState<number | null>(
     null,
@@ -86,7 +83,7 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
   });
 
   // 칼럼 목록이 로드되면 각 칼럼의 카드를 가져옴
-  useQuery({
+  const { data: columnCardsData } = useQuery({
     queryKey: [...QUERY_KEYS.columns(dashboardId), 'cards'],
     queryFn: async () => {
       const cols = columnsData?.data ?? [];
@@ -101,7 +98,6 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
           cursorId: results[i].cursorId,
         };
       });
-      setColumnCards(map);
       return map;
     },
     enabled: !!columnsData?.data?.length,
@@ -239,9 +235,9 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
             <Column
               key={column.id}
               column={column}
-              cards={columnCards[column.id]?.cards ?? []}
-              totalCount={columnCards[column.id]?.totalCount ?? 0}
-              cursorId={columnCards[column.id]?.cursorId}
+              cards={columnCardsData?.[column.id]?.cards ?? []}
+              totalCount={columnCardsData?.[column.id]?.totalCount ?? 0}
+              cursorId={columnCardsData?.[column.id]?.cursorId}
               colorIndex={index}
               onAddCard={handleAddCard}
               onEditColumn={handleEditColumn}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [ ] ✨ 기능 추가
- [x] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 문제 내용

대시보드 상세 페이지에서 다른 페이지로 이동 후 뒤로 가기 등으로 돌아왔을 때
카드 목록이 표시되지 않고 개수가 0으로 나타남

## 원인

카드 데이터가 React Query 캐시와 로컬 `useState`(`columnCards`) 양쪽에
중복 저장되는 구조였고, 렌더링은 로컬 state만 참조

## 📝 작업 내용

- `columnCards` 로컬 state 제거
- `queryFn` 내부의 `setColumnCards()` 사이드이펙트 제거
- 렌더링 참조를 `columnCardsData?.[column.id]`로 변경

## 🔗 관련 이슈

- Resolves #70 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?
