### PR TITLE
feat, fix: 사이드바 대시보드 순서 변경 및 칸반보드 카드 드래그앤드롭 구현, 컬럼 글자 크기 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "part3-team2",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.6",
         "class-variance-authority": "^0.7.1",
@@ -289,6 +292,60 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",

--- a/src/components/dashboard/Column.tsx
+++ b/src/components/dashboard/Column.tsx
@@ -3,6 +3,7 @@
 /**
  * @file Column.tsx
  * @description 칸반 보드의 단일 컬럼 컴포넌트입니다.
+ * SortableContext로 카드 내 순서 변경, useDroppable로 빈 공간에 카드 드롭을 지원합니다.
  *
  * @notes
  * - 컬럼 헤더: 색상 점 + 제목 + 카드 수 chip + 톱니바퀴(수정) 아이콘
@@ -11,39 +12,33 @@
  * - 카드 클릭 → 카드 상세 모달 오픈 (onCardClick 콜백)
  * - 카드 목록은 세로 스크롤, 무한 스크롤 지원 (cursorId 기반)
  * - 반응형: mobile 284px / tablet(md) 544px / desktop(lg) 354px
+ * - useDroppable id는 `col-{id}` 문자열 — 카드 ID(숫자)와 충돌 방지
  */
 
 import { useRef, useEffect } from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import type { Card, Column as ColumnType } from '@/types/dashboard';
 import Button from '@/components/common/Button';
 import SettingIcon from '@/components/common/Icon/SettingIcon';
 import CountCardChip from '@/components/common/Chip/CountCardChip';
 import TaskCard from './TaskCard';
 
-/** 컬럼 상단 색상 점에 사용할 색상 팔레트 (컬럼 순서에 따라 순환) */
-const COLUMN_COLORS = [
-  '#760DDE', // purple
-  '#FFA500', // orange
-  '#76A5EA', // blue
-  '#7AC555', // green
-  '#E876EA', // pink
-];
+const COLUMN_COLORS = ['#760DDE', '#FFA500', '#76A5EA', '#7AC555', '#E876EA'];
 
 interface ColumnProps {
   column: ColumnType;
   cards: Card[];
   totalCount: number;
   colorIndex: number;
-  /** 할 일 추가 모달 오픈 */
   onAddCard: (columnId: number) => void;
-  /** 컬럼 수정 모달 오픈 */
   onEditColumn: (column: ColumnType) => void;
-  /** 카드 상세 모달 오픈 */
   onCardClick: (card: Card) => void;
-  /** 추가 카드 로드 (무한 스크롤) */
   onLoadMore?: (columnId: number, cursorId: number) => void;
   cursorId?: number | null;
-  /** 추가 카드 로딩 중 여부 */
   isLoadingMore?: boolean;
 }
 
@@ -62,6 +57,16 @@ export default function Column({
   const dotColor = COLUMN_COLORS[colorIndex % COLUMN_COLORS.length];
   const sentinelRef = useRef<HTMLDivElement>(null);
   const hasMore = totalCount > cards.length;
+
+  /**
+   * 컬럼 카드 목록 영역 전체를 드롭존으로 설정.
+   * id를 `col-{column.id}` 문자열로 지정해 카드 ID(숫자)와 충돌을 방지.
+   * 카드 목록이 비어있을 때도 드롭이 정상 동작하도록 컨테이너에 연결.
+   */
+  const { setNodeRef, isOver } = useDroppable({
+    id: `col-${column.id}`,
+    data: { type: 'column', columnId: column.id },
+  });
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -91,19 +96,17 @@ export default function Column({
     >
       {/* ── 컬럼 헤더 ── */}
       <div className="flex items-center justify-between px-4 md:px-5 h-[64px] shrink-0">
-        {/* 왼쪽: 색상 점 + 제목 + 카드 수 */}
         <div className="flex items-center gap-2">
           <span
             className="w-2 h-2 rounded-full shrink-0"
             style={{ backgroundColor: dotColor }}
           />
-          <span className="text-lg-bold md:text-xl-bold text-gray-700">
+          <span className="text-lg-bold md:text-2lg-bold text-gray-700">
             {column.title}
           </span>
           <CountCardChip count={totalCount} />
         </div>
 
-        {/* 오른쪽: 톱니바퀴 버튼 */}
         <button
           type="button"
           onClick={() => onEditColumn(column)}
@@ -129,22 +132,38 @@ export default function Column({
         </Button>
       </div>
 
-      {/* ── 카드 목록 (세로 스크롤) ── */}
-      <div className="flex-1 overflow-y-auto px-4 md:px-5 flex flex-col gap-2 pb-4">
-        {cards.map((card) => (
-          <TaskCard key={card.id} card={card} onClick={onCardClick} />
-        ))}
+      {/* ── 카드 목록 (SortableContext + 드롭존 + 세로 스크롤) ── */}
+      <SortableContext
+        items={cards.map((c) => c.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div
+          ref={setNodeRef}
+          className={[
+            'flex-1 overflow-y-auto px-4 md:px-5 flex flex-col gap-2 pb-4',
+            'rounded-b-[4px] transition-colors min-h-[60px]',
+            isOver ? 'bg-brand-violet-light/30' : '',
+          ].join(' ')}
+        >
+          {cards.map((card) => (
+            <TaskCard
+              key={card.id}
+              card={card}
+              columnId={column.id}
+              onClick={onCardClick}
+            />
+          ))}
 
-        {/* 무한 스크롤 sentinel */}
-        {hasMore && <div ref={sentinelRef} className="h-1 shrink-0" />}
+          {/* 무한 스크롤 sentinel */}
+          {hasMore && <div ref={sentinelRef} className="h-1 shrink-0" />}
 
-        {/* 로딩 스피너 */}
-        {isLoadingMore && (
-          <p className="text-center text-xs-regular text-gray-400 py-2">
-            불러오는 중...
-          </p>
-        )}
-      </div>
+          {isLoadingMore && (
+            <p className="text-center text-xs-regular text-gray-400 py-2">
+              불러오는 중...
+            </p>
+          )}
+        </div>
+      </SortableContext>
     </div>
   );
 }

--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -56,6 +56,33 @@ interface ColumnCardState {
   cursorId: number | null;
 }
 
+/** 컬럼의 카드 순서를 localStorage에 저장 */
+function saveColumnOrder(columnId: number, cardIds: number[]) {
+  try {
+    localStorage.setItem(`card-order-col-${columnId}`, JSON.stringify(cardIds));
+  } catch {
+    // 시크릿 모드 등 localStorage 비활성 환경에서는 무시
+  }
+}
+
+/** localStorage에 저장된 순서대로 카드 배열을 정렬 */
+function applySavedOrder(columnId: number, cards: Card[]): Card[] {
+  try {
+    const saved = localStorage.getItem(`card-order-col-${columnId}`);
+    if (!saved) return cards;
+    const savedIds: number[] = JSON.parse(saved);
+    return [...cards].sort((a, b) => {
+      const ai = savedIds.indexOf(a.id);
+      const bi = savedIds.indexOf(b.id);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  } catch {
+    return cards;
+  }
+}
+
 export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
   const [columnCards, setColumnCards] = useState<
     Record<number, ColumnCardState>
@@ -91,36 +118,6 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
       if (state.cards.some((c) => c.id === cardId)) return Number(colId);
     }
     return null;
-  };
-
-  /** 컬럼의 카드 순서를 localStorage에 저장 */
-  const saveColumnOrder = (columnId: number, cardIds: number[]) => {
-    try {
-      localStorage.setItem(
-        `card-order-col-${columnId}`,
-        JSON.stringify(cardIds),
-      );
-    } catch {
-      // 시크릿 모드 등 localStorage 비활성 환경에서는 무시
-    }
-  };
-
-  /** localStorage에 저장된 순서대로 카드 배열을 정렬 */
-  const applySavedOrder = (columnId: number, cards: Card[]): Card[] => {
-    try {
-      const saved = localStorage.getItem(`card-order-col-${columnId}`);
-      if (!saved) return cards;
-      const savedIds: number[] = JSON.parse(saved);
-      return [...cards].sort((a, b) => {
-        const ai = savedIds.indexOf(a.id);
-        const bi = savedIds.indexOf(b.id);
-        if (ai === -1) return 1; // 저장 목록에 없는 신규 카드는 맨 뒤로
-        if (bi === -1) return -1;
-        return ai - bi;
-      });
-    } catch {
-      return cards;
-    }
   };
 
   const sensors = useSensors(
@@ -568,19 +565,9 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
         </DndContext>
       </div>
 
-      {/* 카드 상세 모달 */}
+      {/* 카드 상세 모달 (오버레이는 Cards.tsx 내부에서 처리) */}
       {isCardModalOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
-          onClick={handleCardModalClose}
-        >
-          <div onClick={(e) => e.stopPropagation()}>
-            <Cards
-              onModalClose={handleCardModalClose}
-              cardId={selectedCardId!}
-            />
-          </div>
-        </div>
+        <Cards onModalClose={handleCardModalClose} cardId={selectedCardId!} />
       )}
 
       {/* 칼럼 추가 모달 */}

--- a/src/components/dashboard/DashboardBoard.tsx
+++ b/src/components/dashboard/DashboardBoard.tsx
@@ -4,27 +4,41 @@
  * @file DashboardBoard.tsx
  * @description 대시보드 상세 페이지의 칸반 보드 영역 클라이언트 컴포넌트입니다.
  * React Query로 데이터를 로드하고, 사용자 상호작용을 처리합니다.
+ * 드래그앤드롭으로 카드를 컬럼 간 이동할 수 있습니다.
  *
  * @notes
  * - 모달 오픈 콜백(onCardClick, onAddCard 등)은 Column/TaskCard에 연결되어 있습니다.
- * - NOTE: 서버 사이드 인증(쿠키 기반)이 구축되면 page.tsx에서 initialData를 내려줄 수 있습니다.
- *   현재는 localStorage 토큰 방식이라 클라이언트에서 전부 로드합니다.
+ * - 드래그 시작 시 activeCard 상태 저장 → DragOverlay로 ghost 카드 표시
+ * - 드롭 시 optimistic update 후 updateCard API 호출, 실패 시 롤백
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragStartEvent,
+  type DragEndEvent,
+  type DragOverEvent,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
 import { useDashboardStore } from '@/store/useDashboardStore';
 import type { Column as ColumnType, Card } from '@/types/dashboard';
 import {
   getDashboard,
   getColumns,
-  getMembers,
   getCards,
   createColumn,
   updateColumn,
   deleteColumn,
+  updateCard,
 } from '@/api/dashboard';
 import Column from './Column';
+import TaskCard from './TaskCard';
 import Button from '@/components/common/Button';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import Cards from '@/components/Modal/Cards/Cards';
@@ -42,14 +56,77 @@ interface ColumnCardState {
   cursorId: number | null;
 }
 
-const MAX_VISIBLE_MEMBERS = 4;
-
 export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
   const [columnCards, setColumnCards] = useState<
     Record<number, ColumnCardState>
   >({});
   const [loadingColumnIds, setLoadingColumnIds] = useState<Set<number>>(
     new Set(),
+  );
+
+  /** 드래그 중인 카드 정보 (DragOverlay 렌더링용) */
+  const [activeCard, setActiveCard] = useState<{
+    card: Card;
+    columnId: number;
+  } | null>(null);
+
+  /**
+   * columnCardsRef: columnCards state의 최신 값을 항상 참조.
+   * onDragOver / onDragEnd 핸들러에서 stale closure 없이 읽기 위해 사용.
+   */
+  const columnCardsRef = useRef(columnCards);
+  useEffect(() => {
+    columnCardsRef.current = columnCards;
+  }, [columnCards]);
+
+  /**
+   * clonedCardsRef: 드래그 시작 시 columnCards 스냅샷 저장.
+   * API 실패 시 이 값으로 롤백.
+   */
+  const clonedCardsRef = useRef<Record<number, ColumnCardState> | null>(null);
+
+  /** 카드 ID로 현재 속한 컬럼 ID를 탐색 */
+  const findColumnId = (cardId: number): number | null => {
+    for (const [colId, state] of Object.entries(columnCardsRef.current)) {
+      if (state.cards.some((c) => c.id === cardId)) return Number(colId);
+    }
+    return null;
+  };
+
+  /** 컬럼의 카드 순서를 localStorage에 저장 */
+  const saveColumnOrder = (columnId: number, cardIds: number[]) => {
+    try {
+      localStorage.setItem(
+        `card-order-col-${columnId}`,
+        JSON.stringify(cardIds),
+      );
+    } catch {
+      // 시크릿 모드 등 localStorage 비활성 환경에서는 무시
+    }
+  };
+
+  /** localStorage에 저장된 순서대로 카드 배열을 정렬 */
+  const applySavedOrder = (columnId: number, cards: Card[]): Card[] => {
+    try {
+      const saved = localStorage.getItem(`card-order-col-${columnId}`);
+      if (!saved) return cards;
+      const savedIds: number[] = JSON.parse(saved);
+      return [...cards].sort((a, b) => {
+        const ai = savedIds.indexOf(a.id);
+        const bi = savedIds.indexOf(b.id);
+        if (ai === -1) return 1; // 저장 목록에 없는 신규 카드는 맨 뒤로
+        if (bi === -1) return -1;
+        return ai - bi;
+      });
+    } catch {
+      return cards;
+    }
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
   );
 
   const [isCardModalOpen, setIsCardModalOpen] = useState(false);
@@ -110,21 +187,22 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
     enabled: !!columnsData?.data?.length,
   });
 
-  const { data: membersData } = useQuery({
-    queryKey: QUERY_KEYS.members(dashboardId),
-    queryFn: () => getMembers(dashboardId),
-  });
-
   useEffect(() => {
-    if (columnCardsData) {
-      setColumnCards(columnCardsData);
+    if (!columnCardsData) return;
+
+    // localStorage에 저장된 순서가 있으면 복원, 없으면 API 기본 순서 사용
+    const ordered: Record<number, ColumnCardState> = {};
+    for (const [colId, state] of Object.entries(columnCardsData)) {
+      const id = Number(colId);
+      ordered[id] = {
+        ...state,
+        cards: applySavedOrder(id, state.cards),
+      };
     }
+    setColumnCards(ordered);
   }, [columnCardsData]);
 
   const columns = columnsData?.data ?? [];
-  const members = membersData?.members ?? [];
-  const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS);
-  const extraMemberCount = Math.max(0, members.length - MAX_VISIBLE_MEMBERS);
 
   // ── 이벤트 핸들러 ──
 
@@ -213,6 +291,178 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
     setSelectedCardId(null);
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    const data = event.active.data.current as {
+      card: Card;
+      columnId: number;
+    };
+    setActiveCard({ card: data.card, columnId: data.columnId });
+    // 드래그 시작 시 현재 상태 스냅샷 저장 (API 실패 시 롤백용)
+    clonedCardsRef.current = JSON.parse(JSON.stringify(columnCardsRef.current));
+  };
+
+  /**
+   * 드래그 중 카드가 다른 컬럼 위에 올라왔을 때 즉시 이동(optimistic).
+   * - 같은 컬럼 내 이동: useSortable 애니메이션이 처리하므로 state 변경 없음
+   * - 다른 컬럼으로 이동: 카드가 올라간 카드 바로 위에 삽입
+   */
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const activeId = active.id as number;
+    const sourceColumnId = findColumnId(activeId);
+    if (sourceColumnId === null) return;
+
+    const overData = over.data.current as
+      | { type?: string; columnId?: number }
+      | undefined;
+
+    let targetColumnId: number | null = null;
+    let overCardId: number | null = null;
+
+    if (overData?.type === 'card') {
+      targetColumnId = overData.columnId ?? null;
+      overCardId = over.id as number;
+    } else if (overData?.type === 'column') {
+      targetColumnId = overData.columnId ?? null;
+    }
+
+    if (!targetColumnId || sourceColumnId === targetColumnId) return;
+
+    setColumnCards((prev) => {
+      const sourceCards = [...(prev[sourceColumnId]?.cards ?? [])];
+      const movingCard = sourceCards.find((c) => c.id === activeId);
+      if (!movingCard) return prev;
+
+      const newSource = sourceCards.filter((c) => c.id !== activeId);
+      const newTarget = [...(prev[targetColumnId!]?.cards ?? [])];
+
+      if (overCardId !== null) {
+        const overIndex = newTarget.findIndex((c) => c.id === overCardId);
+        if (overIndex >= 0) {
+          newTarget.splice(overIndex, 0, {
+            ...movingCard,
+            columnId: targetColumnId!,
+          });
+        } else {
+          newTarget.push({ ...movingCard, columnId: targetColumnId! });
+        }
+      } else {
+        newTarget.push({ ...movingCard, columnId: targetColumnId! });
+      }
+
+      return {
+        ...prev,
+        [sourceColumnId]: {
+          ...prev[sourceColumnId],
+          cards: newSource,
+          totalCount: Math.max(0, (prev[sourceColumnId]?.totalCount ?? 1) - 1),
+        },
+        [targetColumnId!]: {
+          ...prev[targetColumnId!],
+          cards: newTarget,
+          totalCount: (prev[targetColumnId!]?.totalCount ?? 0) + 1,
+        },
+      };
+    });
+  }, []);
+
+  /**
+   * 드롭 완료 처리.
+   * - 같은 컬럼 내: arrayMove로 최종 순서 확정 (state 업데이트)
+   * - 다른 컬럼: handleDragOver에서 이미 이동됨 → API만 호출
+   * - API 실패 시 clonedCardsRef로 롤백
+   */
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveCard(null);
+
+    const activeId = active.id as number;
+    const currentColumnId = findColumnId(activeId);
+
+    if (!over || currentColumnId === null) {
+      if (clonedCardsRef.current) setColumnCards(clonedCardsRef.current);
+      clonedCardsRef.current = null;
+      return;
+    }
+
+    const overData = over.data.current as
+      | { type?: string; columnId?: number }
+      | undefined;
+    const overCardId = over.id as number;
+
+    // 같은 컬럼 내 순서 변경: arrayMove로 최종 위치 확정
+    if (
+      overData?.type === 'card' &&
+      overData.columnId === currentColumnId &&
+      activeId !== overCardId
+    ) {
+      const cards = columnCardsRef.current[currentColumnId]?.cards ?? [];
+      const oldIdx = cards.findIndex((c) => c.id === activeId);
+      const newIdx = cards.findIndex((c) => c.id === overCardId);
+
+      if (oldIdx !== -1 && newIdx !== -1 && oldIdx !== newIdx) {
+        setColumnCards((prev) => ({
+          ...prev,
+          [currentColumnId]: {
+            ...prev[currentColumnId],
+            cards: arrayMove(prev[currentColumnId].cards, oldIdx, newIdx),
+          },
+        }));
+      }
+    }
+
+    // 원래 컬럼 찾기 (API 호출 여부 판단)
+    const savedClone = clonedCardsRef.current;
+    clonedCardsRef.current = null;
+
+    if (!savedClone) return;
+
+    let originalColumnId: number | null = null;
+    for (const [colId, state] of Object.entries(savedClone)) {
+      if (state.cards.some((c) => c.id === activeId)) {
+        originalColumnId = Number(colId);
+        break;
+      }
+    }
+
+    /**
+     * 드래그 완료 후 영향받은 컬럼의 최종 순서를 localStorage에 저장.
+     * setColumnCards 콜백 안에서 prev를 읽어야 arrayMove 적용 후의
+     * 최신 state를 기준으로 저장할 수 있음.
+     */
+    const colsToSave = new Set<number>();
+    colsToSave.add(currentColumnId);
+    if (originalColumnId !== null) colsToSave.add(originalColumnId);
+
+    setColumnCards((prev) => {
+      for (const colId of colsToSave) {
+        saveColumnOrder(
+          colId,
+          (prev[colId]?.cards ?? []).map((c) => c.id),
+        );
+      }
+      return prev; // state 변경 없이 최신 값만 읽음
+    });
+
+    // 컬럼이 바뀐 경우에만 API 호출
+    if (originalColumnId !== null && originalColumnId !== currentColumnId) {
+      try {
+        await updateCard(activeId, { columnId: currentColumnId });
+      } catch {
+        // API 실패 시 state와 localStorage 모두 롤백
+        setColumnCards(savedClone);
+        for (const [colId, state] of Object.entries(savedClone)) {
+          saveColumnOrder(
+            Number(colId),
+            state.cards.map((c) => c.id),
+          );
+        }
+      }
+    }
+  };
+
   const handleAddColumn = () => {
     setAddColumnModal({ isOpen: true, title: '', error: '' });
   };
@@ -240,11 +490,6 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
     }
   };
 
-  const handleInvite = () => {
-    // 초대하기 모달 오픈
-    console.log('초대하기 요청');
-  };
-
   if (isDashboardLoading || isColumnsLoading) {
     return (
       <div className="flex items-center justify-center flex-1 h-full min-h-[calc(100vh-64px)]">
@@ -267,38 +512,60 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
     <div className="flex flex-col h-full">
       {/* ── 칸반 보드 ── */}
       <div className="flex-1 overflow-hidden bg-gray-100">
-        <div className="flex flex-col lg:flex-row h-full overflow-y-auto lg:overflow-y-hidden lg:overflow-x-auto">
-          {columns.map((column, index) => (
-            <Column
-              key={column.id}
-              column={column}
-              cards={columnCards[column.id]?.cards ?? []}
-              totalCount={columnCards[column.id]?.totalCount ?? 0}
-              cursorId={columnCards[column.id]?.cursorId}
-              colorIndex={index}
-              onAddCard={handleAddCard}
-              onEditColumn={handleEditColumn}
-              onCardClick={handleCardClick}
-              onLoadMore={handleLoadMore}
-              isLoadingMore={loadingColumnIds.has(column.id)}
-            />
-          ))}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
+          <div className="flex flex-col lg:flex-row h-full overflow-y-auto lg:overflow-y-hidden lg:overflow-x-auto">
+            {columns.map((column, index) => (
+              <Column
+                key={column.id}
+                column={column}
+                cards={columnCards[column.id]?.cards ?? []}
+                totalCount={columnCards[column.id]?.totalCount ?? 0}
+                cursorId={columnCards[column.id]?.cursorId}
+                colorIndex={index}
+                onAddCard={handleAddCard}
+                onEditColumn={handleEditColumn}
+                onCardClick={handleCardClick}
+                onLoadMore={handleLoadMore}
+                isLoadingMore={loadingColumnIds.has(column.id)}
+              />
+            ))}
 
-          {/* 새로운 컬럼 추가하기 */}
-          <div className="flex items-start pt-4 lg:pt-[64px] px-4 md:px-5 pb-8 lg:pb-0 shrink-0">
-            <Button
-              variant="secondary"
-              size="add_column"
-              onClick={handleAddColumn}
-              className="w-full md:w-full lg:w-[354px]"
-            >
-              새로운 컬럼 추가하기
-              <span className="w-5 h-5 flex items-center justify-center rounded bg-brand-violet-light text-brand-violet text-lg-bold leading-none">
-                +
-              </span>
-            </Button>
+            {/* 새로운 컬럼 추가하기 */}
+            <div className="flex items-start pt-4 lg:pt-[64px] px-4 md:px-5 pb-8 lg:pb-0 shrink-0">
+              <Button
+                variant="secondary"
+                size="add_column"
+                onClick={handleAddColumn}
+                className="w-full md:w-full lg:w-[354px]"
+              >
+                새로운 컬럼 추가하기
+                <span className="w-5 h-5 flex items-center justify-center rounded bg-brand-violet-light text-brand-violet text-lg-bold leading-none">
+                  +
+                </span>
+              </Button>
+            </div>
           </div>
-        </div>
+
+          {/* 드래그 중 ghost 카드 */}
+          <DragOverlay>
+            {activeCard && (
+              <div className="rotate-2 shadow-xl opacity-95">
+                <TaskCard
+                  card={activeCard.card}
+                  columnId={activeCard.columnId}
+                  onClick={() => {}}
+                  isDragOverlay
+                />
+              </div>
+            )}
+          </DragOverlay>
+        </DndContext>
       </div>
 
       {/* 카드 상세 모달 */}
@@ -412,12 +679,6 @@ export default function DashboardBoard({ dashboardId }: DashboardBoardProps) {
           columnId={createCardColumnId}
         />
       )}
-
-      {/*
-       * NOTE: 아래 모달들은 컴포넌트 완성 후 이 위치에 추가합니다.
-       *
-       * - 초대하기 모달      → handleInvite()
-       */}
     </div>
   );
 }

--- a/src/components/dashboard/TaskCard.tsx
+++ b/src/components/dashboard/TaskCard.tsx
@@ -1,15 +1,20 @@
+'use client';
+
 /**
  * @file TaskCard.tsx
  * @description 칸반 보드의 할 일 카드 컴포넌트입니다.
- * 카드를 클릭하면 상세 모달이 열립니다.
+ * 카드를 클릭하면 상세 모달이 열리고, 드래그앤드롭으로 컬럼 간 이동이 가능합니다.
  *
  * @notes
  * - 이미지가 있는 경우 카드 상단에 썸네일로 표시됩니다.
  * - 태그는 배경색 랜덤 적용 (TagChip 컴포넌트 사용)
  * - 담당자 프로필 이미지 또는 이니셜 아바타 표시
+ * - isDragOverlay=true 이면 드래그 훅을 비활성화하여 오버레이에서 사용 가능
  */
 
 import Image from 'next/image';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { Card } from '@/types/dashboard';
 import CalendarIcon from '@/components/common/Icon/CalendarIcon';
 import TagChip from '@/components/common/Chip/TagChip';
@@ -17,18 +22,51 @@ import UserProfileImage from '@/components/common/User/UserProfileImage';
 
 interface TaskCardProps {
   card: Card;
+  /** 이 카드가 속한 컬럼 ID (드래그 데이터에 포함) */
+  columnId: number;
   /** 카드 클릭 시 상세 모달 오픈 핸들러 */
   onClick: (card: Card) => void;
+  /** DragOverlay 내부에서 렌더링될 때 true — 드래그 훅 비활성화 */
+  isDragOverlay?: boolean;
 }
 
-export default function TaskCard({ card, onClick }: TaskCardProps) {
+export default function TaskCard({
+  card,
+  columnId,
+  onClick,
+  isDragOverlay = false,
+}: TaskCardProps) {
   const { title, tags, dueDate, assignee, imageUrl } = card;
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: card.id,
+    data: { type: 'card', card, columnId },
+    disabled: isDragOverlay,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1,
+    touchAction: 'none',
+  };
 
   return (
     <button
+      ref={setNodeRef}
       type="button"
+      style={style}
       onClick={() => onClick(card)}
-      className="w-full text-left bg-white rounded-lg border border-gray-300 p-4 hover:border-brand-violet transition-colors group"
+      className="w-full text-left bg-white rounded-lg border border-gray-300 p-4 hover:border-brand-violet transition-colors group cursor-grab active:cursor-grabbing"
+      {...attributes}
+      {...listeners}
     >
       {/* 썸네일 이미지 */}
       {imageUrl && (

--- a/src/components/layout/SideMenu/SideMenu.tsx
+++ b/src/components/layout/SideMenu/SideMenu.tsx
@@ -4,17 +4,35 @@
  * @file SideMenu.tsx
  * @description 서비스 좌측에 고정되는 네비게이션 사이드바 컴포넌트입니다.
  * 대시보드 목록을 보여주고, 현재 위치에 따라 활성 항목을 하이라이트 처리합니다.
+ * 드래그앤드롭으로 대시보드 순서를 변경할 수 있습니다.
  * @author 하늘
  * @notes
  * - 반응형 3단계: 데스크탑(xl, 300px) / 태블릿(md, 160px) / 모바일(67px)
  * - 15개 초과 시 하단 페이지네이션으로 목록이 나뉩니다.
  * - 현재 pathname 감지를 위해 'use client'가 선언되어 있습니다.
+ * - 드래그 시작 전 8px 이상 이동해야 드래그로 인식 (클릭과 구분).
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDndMonitor,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import AddBoxIcon from '@/components/common/Icon/AddBoxIcon';
 import CrownIcon from '@/components/common/Icon/CrownIcon';
 import Pagination from '@/components/common/Pagination/Pagination';
@@ -22,12 +40,163 @@ import Logo from '@/components/common/Logo';
 import { cn } from '@/lib/utils';
 import { getDashboards } from '@/api/dashboard';
 import { QUERY_KEYS } from '@/constants/queryKeys';
+import type { Dashboard } from '@/types/dashboard';
 
 const PAGE_SIZE = 15;
+
+/**
+ * 모듈 레벨 플래그: 드래그가 발생했는지 추적.
+ * React state/ref 대신 모듈 변수를 사용해 렌더링 사이클과 무관하게
+ * 동기적으로 읽고 쓸 수 있어 pointerup → click 이벤트 순서에서 안정적으로 동작.
+ */
+let hasDragged = false;
+
+interface SortableDashboardItemProps {
+  dashboard: Dashboard;
+  isActive: boolean;
+}
+
+function SortableDashboardItem({
+  dashboard,
+  isActive,
+}: SortableDashboardItemProps) {
+  const router = useRouter();
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: dashboard.id });
+
+  useDndMonitor({
+    onDragStart() {
+      hasDragged = false;
+    },
+    onDragEnd() {
+      hasDragged = true;
+      setTimeout(() => {
+        hasDragged = false;
+      }, 100);
+    },
+  });
+
+  const handleClick = () => {
+    if (!hasDragged) {
+      router.push(`/dashboard/${dashboard.id}`);
+    }
+  };
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    zIndex: isDragging ? 10 : undefined,
+    position: 'relative',
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      onClick={handleClick}
+      {...attributes}
+      {...listeners}
+    >
+      {/* mobile */}
+      <div
+        className={cn(
+          'md:hidden flex items-center justify-center',
+          'w-10 h-10 ml-[14px] rounded-[4px] transition-colors cursor-pointer',
+          isActive ? 'bg-white' : 'hover:bg-gray-100',
+          isDragging && 'bg-gray-100',
+        )}
+      >
+        <span
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ backgroundColor: dashboard.color }}
+        />
+      </div>
+
+      {/* tablet */}
+      <div
+        className={cn(
+          'hidden md:flex lg:hidden items-center gap-4',
+          'h-[43px] mx-2 px-[10px] rounded-[4px] transition-colors cursor-pointer',
+          isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
+          isDragging && 'bg-gray-100',
+        )}
+      >
+        <span
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ backgroundColor: dashboard.color }}
+        />
+        <span className="flex items-center gap-1.5 flex-1 min-w-0">
+          <span
+            className={cn(
+              'truncate text-lg-medium',
+              isActive ? 'text-gray-700' : 'text-gray-500',
+            )}
+          >
+            {dashboard.title}
+          </span>
+          {dashboard.createdByMe && (
+            <CrownIcon width={15} height={12} className="shrink-0" />
+          )}
+        </span>
+      </div>
+
+      {/* desktop */}
+      <div
+        className={cn(
+          'hidden lg:flex items-center gap-4',
+          'h-[50px] mx-3 px-3 rounded-[4px] transition-colors cursor-pointer',
+          isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
+          isDragging && 'bg-gray-100',
+        )}
+      >
+        <span
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ backgroundColor: dashboard.color }}
+        />
+        <span className="flex items-center gap-1.5 flex-1 min-w-0">
+          <span
+            className={cn(
+              'truncate text-2lg-medium',
+              isActive ? 'text-gray-700' : 'text-gray-500',
+            )}
+          >
+            {dashboard.title}
+          </span>
+          {dashboard.createdByMe && (
+            <CrownIcon width={18} height={14} className="shrink-0" />
+          )}
+        </span>
+      </div>
+    </li>
+  );
+}
 
 const SideMenu = () => {
   const pathname = usePathname();
   const [page, setPage] = useState(1);
+
+  /**
+   * 페이지별 드래그 순서를 메모리에 보관.
+   * key: storageKey(`dashboard-order-page-${page}`)
+   * value: 해당 페이지에서 드래그로 재정렬된 대시보드 ID 배열
+   */
+  const [localOrderMap, setLocalOrderMap] = useState<Record<string, number[]>>(
+    {},
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+  );
 
   const { data } = useQuery({
     queryKey: [...QUERY_KEYS.dashboards(), page],
@@ -38,9 +207,59 @@ const SideMenu = () => {
   const totalCount = data?.totalCount ?? 0;
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
+  const storageKey = `dashboard-order-page-${page}`;
+
+  /**
+   * 표시할 대시보드 순서를 계산.
+   * 우선순위: 드래그 인메모리 순서 > localStorage 저장 순서 > API 기본 순서
+   * useEffect + setState 대신 useMemo로 처리해 effect 내 setState 규칙 위반을 방지.
+   */
+  const orderedDashboards = useMemo(() => {
+    if (dashboards.length === 0) return [];
+
+    const applyOrder = (ids: number[]) =>
+      [...dashboards].sort((a, b) => {
+        const ai = ids.indexOf(a.id);
+        const bi = ids.indexOf(b.id);
+        if (ai === -1) return 1;
+        if (bi === -1) return -1;
+        return ai - bi;
+      });
+
+    const inMemory = localOrderMap[storageKey];
+    if (inMemory?.length) return applyOrder(inMemory);
+
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) return applyOrder(JSON.parse(saved));
+    } catch {
+      /* ignore */
+    }
+
+    return dashboards;
+  }, [dashboards, localOrderMap, storageKey]);
+
   const handlePrevPage = () => setPage((prev) => Math.max(1, prev - 1));
   const handleNextPage = () =>
     setPage((prev) => Math.min(totalPages, prev + 1));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedDashboards.findIndex((d) => d.id === active.id);
+    const newIndex = orderedDashboards.findIndex((d) => d.id === over.id);
+    const newOrder = arrayMove(orderedDashboards, oldIndex, newIndex);
+    const newIds = newOrder.map((d) => d.id);
+
+    setLocalOrderMap((prev) => ({ ...prev, [storageKey]: newIds }));
+
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(newIds));
+    } catch {
+      // 시크릿 모드 등 localStorage 비활성 환경에서는 무시
+    }
+  };
 
   return (
     <aside
@@ -67,7 +286,6 @@ const SideMenu = () => {
         <span className="hidden md:block text-xs-semibold text-gray-500">
           Dash Boards
         </span>
-        {/* NOTE: 모바일에서는 텍스트 없이 버튼만 left: 24px 위치에 표시 */}
         <button
           type="button"
           className="w-5 h-5 flex items-center justify-center text-gray-500 hover:text-gray-700 transition-colors"
@@ -77,100 +295,37 @@ const SideMenu = () => {
         </button>
       </div>
 
-      {/* ── 대시보드 목록 ── */}
+      {/* ── 대시보드 목록 (드래그앤드롭) ── */}
       <div className="flex-1 overflow-y-auto">
-        <ul className="flex flex-col gap-1.5 md:gap-0.5 lg:gap-2">
-          {dashboards.map((dashboard) => {
-            const isActive =
-              pathname === `/dashboard/${dashboard.id}` ||
-              pathname.startsWith(`/dashboard/${dashboard.id}/`);
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={orderedDashboards.map((d) => d.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="flex flex-col gap-1.5 md:gap-0.5 lg:gap-2">
+              {orderedDashboards.map((dashboard) => {
+                const isActive =
+                  pathname === `/dashboard/${dashboard.id}` ||
+                  pathname.startsWith(`/dashboard/${dashboard.id}/`);
 
-            return (
-              <li key={dashboard.id}>
-                <Link href={`/dashboard/${dashboard.id}`}>
-                  {/* mobile: 컬러 점 40×40 박스 (left: 14px, 선택 시 흰 배경) */}
-                  <div
-                    className={cn(
-                      'md:hidden flex items-center justify-center',
-                      'w-10 h-10 ml-[14px] rounded-[4px] transition-colors',
-                      isActive ? 'bg-white' : 'hover:bg-gray-100',
-                    )}
-                  >
-                    <span
-                      className="w-2 h-2 rounded-full shrink-0"
-                      style={{ backgroundColor: dashboard.color }}
-                    />
-                  </div>
-
-                  {/* tablet: [dot] gap-4 [text + crown(gap-1.5)] */}
-                  <div
-                    className={cn(
-                      'hidden md:flex lg:hidden items-center gap-4',
-                      'h-[43px] mx-2 px-[10px] rounded-[4px] transition-colors',
-                      isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
-                    )}
-                  >
-                    <span
-                      className="w-2 h-2 rounded-full shrink-0"
-                      style={{ backgroundColor: dashboard.color }}
-                    />
-                    <span className="flex items-center gap-1.5 flex-1 min-w-0">
-                      <span
-                        className={cn(
-                          'truncate text-lg-medium',
-                          isActive ? 'text-gray-700' : 'text-gray-500',
-                        )}
-                      >
-                        {dashboard.title}
-                      </span>
-                      {dashboard.createdByMe && (
-                        <CrownIcon
-                          width={15}
-                          height={12}
-                          className="shrink-0"
-                        />
-                      )}
-                    </span>
-                  </div>
-
-                  {/* desktop: [dot] gap-4 [text + crown(gap-1.5)] */}
-                  <div
-                    className={cn(
-                      'hidden lg:flex items-center gap-4',
-                      'h-[50px] mx-3 px-3 rounded-[4px] transition-colors',
-                      isActive ? 'bg-brand-violet-light' : 'hover:bg-gray-100',
-                    )}
-                  >
-                    <span
-                      className="w-2 h-2 rounded-full shrink-0"
-                      style={{ backgroundColor: dashboard.color }}
-                    />
-                    <span className="flex items-center gap-1.5 flex-1 min-w-0">
-                      <span
-                        className={cn(
-                          'truncate text-2lg-medium',
-                          isActive ? 'text-gray-700' : 'text-gray-500',
-                        )}
-                      >
-                        {dashboard.title}
-                      </span>
-                      {dashboard.createdByMe && (
-                        <CrownIcon
-                          width={18}
-                          height={14}
-                          className="shrink-0"
-                        />
-                      )}
-                    </span>
-                  </div>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+                return (
+                  <SortableDashboardItem
+                    key={dashboard.id}
+                    dashboard={dashboard}
+                    isActive={isActive}
+                  />
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
       </div>
 
-      {/* ── 페이지네이션 (tablet/desktop만 표시, 15개 초과 시에만 렌더링) ── */}
+      {/* ── 페이지네이션 ── */}
       {totalPages > 1 && (
         <div className="hidden md:flex items-center gap-3 shrink-0 px-5 pt-6 lg:pt-8 pb-4">
           <Pagination


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [x] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- 드래그앤드롭으로 대시보드 목록 순서 변경 기능 추가
- 카드를 드래그해 다른 컬럼으로 이동 기능 추가
- 같은 컬럼 내 카드 순서 변경 기능 추가
- 드롭 성공 즉시 UI반영 후 API호출


## 🔗 관련 이슈

- Resolves #79 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?
