### PR TITLE
feat: 마이페이지 프로필 및 비밀번호 변경 UI/인터랙션 구현 (API 연동 전 단계)

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -6,12 +6,128 @@
 
 'use client';
 
+import Image from 'next/image';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
 import Input from '@/components/common/Input/Input';
 import Button from '@/components/common/Button';
-import { useRouter } from 'next/navigation';
 
 export default function MyPage() {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const initialEmail = 'johndoe@gmail.com';
+  const initialNickname = '배유철';
+  const initialProfileImageUrl = null;
+
+  const [nickname, setNickname] = useState(initialNickname);
+  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(
+    initialProfileImageUrl,
+  );
+
+  // 비밀번호 상태
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  // 에러 상태
+  const [isPasswordMismatch, setIsPasswordMismatch] = useState(false);
+
+  const isNicknameChanged = nickname !== initialNickname;
+  const isImageChanged = selectedImageFile !== null;
+  const isProfileChanged = isNicknameChanged || isImageChanged;
+
+  const isPasswordFormValid =
+    currentPassword !== '' && newPassword !== '' && confirmPassword !== '';
+
+  useEffect(() => {
+    return () => {
+      if (previewImageUrl && selectedImageFile) {
+        URL.revokeObjectURL(previewImageUrl);
+      }
+    };
+  }, [previewImageUrl, selectedImageFile]);
+
+  const handleCurrentPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setCurrentPassword(e.target.value);
+  };
+
+  const handleNewPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setNewPassword(e.target.value);
+  };
+
+  const handleConfirmPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setConfirmPassword(e.target.value);
+  };
+
+  // blur 시 검증
+  const handleConfirmPasswordBlur = () => {
+    if (newPassword !== confirmPassword) {
+      setIsPasswordMismatch(true);
+    } else {
+      setIsPasswordMismatch(false);
+    }
+  };
+
+  // 변경 버튼 클릭
+  const handlePasswordChange = () => {
+    if (!isPasswordFormValid) return;
+
+    // 현재 비밀번호 검증 (임시)
+    const mockCurrentPassword = '1234'; // TODO: API 연동 시 제거
+
+    if (currentPassword !== mockCurrentPassword) {
+      alert('현재 비밀번호가 틀립니다');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setIsPasswordMismatch(true);
+      return;
+    }
+
+    // TODO: 비밀번호 변경 API 연결
+    console.log({
+      currentPassword,
+      newPassword,
+    });
+  };
+  const handleNicknameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setNickname(event.target.value);
+  };
+
+  const handleProfileImageButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleProfileImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const imageFile = event.target.files?.[0];
+
+    if (!imageFile) {
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(imageFile);
+
+    setSelectedImageFile(imageFile);
+    setPreviewImageUrl(objectUrl);
+
+    // NOTE: 같은 파일을 다시 선택해도 change 이벤트가 동작하도록 value를 초기화합니다.
+    event.target.value = '';
+  };
+
+  const handleProfileSave = () => {
+    if (!isProfileChanged) {
+      return;
+    }
+
+    console.log({
+      nickname,
+      selectedImageFile,
+    });
+  };
 
   return (
     <div className="flex flex-col p-6">
@@ -30,26 +146,61 @@ export default function MyPage() {
           </h2>
 
           <div className="flex items-start gap-[42px]">
-            <div className="relative h-[180px] w-[180px] shrink-0 rounded-md bg-[#f5f5f5]">
+            <div className="relative h-[180px] w-[180px] shrink-0 overflow-hidden rounded-md bg-[#f5f5f5]">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleProfileImageChange}
+              />
+
               <button
                 type="button"
-                className="flex h-full w-full items-center justify-center text-3xl-semibold text-brand-violet"
+                onClick={handleProfileImageButtonClick}
+                className="h-full w-full"
+                aria-label="프로필 이미지 업로드"
               >
-                +
+                {previewImageUrl ? (
+                  <div className="relative h-full w-full">
+                    <Image
+                      src={previewImageUrl}
+                      alt="프로필 미리보기"
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-3xl-semibold text-brand-violet">
+                    +
+                  </div>
+                )}
               </button>
             </div>
 
             <div className="flex w-full flex-col gap-4">
               <Input
                 label="이메일"
-                value="johndoe@gmail.com"
+                value={initialEmail}
                 readOnly
                 className="bg-white"
               />
 
-              <Input label="닉네임" value="배유철" readOnly />
+              <Input
+                label="닉네임"
+                value={nickname}
+                onChange={handleNicknameChange}
+                placeholder="닉네임 입력"
+                maxLength={10}
+              />
 
-              <Button size="modal_lg" className="w-full">
+              <Button
+                size="modal_lg"
+                className="w-full"
+                disabled={!isProfileChanged}
+                onClick={handleProfileSave}
+              >
                 저장
               </Button>
             </div>
@@ -66,14 +217,16 @@ export default function MyPage() {
               label="현재 비밀번호"
               type="password"
               placeholder="비밀번호 입력"
-              readOnly
+              value={currentPassword}
+              onChange={handleCurrentPasswordChange}
             />
 
             <Input
               label="새 비밀번호"
               type="password"
               placeholder="새 비밀번호 입력"
-              readOnly
+              value={newPassword}
+              onChange={handleNewPasswordChange}
             />
 
             <div>
@@ -81,13 +234,26 @@ export default function MyPage() {
                 label="새 비밀번호 확인"
                 type="password"
                 placeholder="새 비밀번호 입력"
-                readOnly
+                value={confirmPassword}
+                onChange={handleConfirmPasswordChange}
+                onBlur={handleConfirmPasswordBlur}
+                isError={isPasswordMismatch}
+                errorMessage={
+                  isPasswordMismatch
+                    ? '비밀번호가 일치하지 않습니다'
+                    : undefined
+                }
               />
               {/* 에러메시지 공간 확보 */}
               <div className="mt-1 h-5" />
             </div>
 
-            <Button size="modal_lg" className="w-full">
+            <Button
+              size="modal_lg"
+              className="w-full"
+              disabled={!isPasswordFormValid}
+              onClick={handlePasswordChange}
+            >
               변경
             </Button>
           </div>


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [X] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [X] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- 프로필 섹션 기능 구현 (API 연동 전 단계)
  - 닉네임 state 연결 및 변경 감지 로직 구현
  - 프로필 이미지 업로드 (hidden input) 및 미리보기 기능 구현
  - 닉네임/이미지 변경 여부에 따른 저장 버튼 활성화 처리

- 비밀번호 변경 섹션 기능 구현 (API 연동 전 단계)
  - 현재/새 비밀번호/확인 입력 state 관리
  - 모든 input 입력 여부 기반 버튼 활성화 처리
  - confirm input blur 시 비밀번호 불일치 검증 및 에러 UI 반영
  - 현재 비밀번호 임시 검증 로직(mock) 적용

## 📸 스크린샷 (UI 변경 시 권장)

| 변경 전 | 변경 후 |
| ------- | ------- |
|         |         |

## 🔗 관련 이슈

- Resolves #86 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [X] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [ ] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [ ] 불필요한 `console.log`나 주석을 지웠나요?
- [X] (선택) 리뷰어가 특별히 확인해 주었으면 하는 부분이 있나요?

- 인증 관련 401 이슈: 현재 /mypage 진입 시 콘솔에 401 에러가 발생하고 있습니다. 다음단계에서 인증 흐름 및 토큰 처리 정리 시 함께 해결할 예정입니다.
- 비밀번호 검증 임시 로직: 실제 비밀번호 변경 API 연동 시 해당 로직은 제거될 예정입니다.
