### PR TITLE
[feat] mypage api 연동 

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -43,3 +43,15 @@ export async function updateMyInfo(
   const { data } = await api.put<User>('/users/me', payload);
   return data;
 }
+
+export interface ChangePasswordPayload {
+  password: string;
+  newPassword: string;
+}
+
+/** 비밀번호 변경 */
+export async function changePassword(
+  payload: ChangePasswordPayload,
+): Promise<void> {
+  await api.put('/auth/password', payload);
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,45 @@
+import api from './axios';
+import type { User } from '@/types/user';
+
+export interface UpdateMyInfoPayload {
+  nickname?: string;
+  profileImageUrl?: string | null;
+}
+
+export interface UploadProfileImageResponse {
+  profileImageUrl: string;
+}
+
+/** 내 정보 조회 */
+export async function getMyInfo(): Promise<User> {
+  const { data } = await api.get<User>('/users/me');
+  return data;
+}
+
+/** 프로필 이미지 업로드 */
+export async function uploadProfileImage(
+  imageFile: File,
+): Promise<UploadProfileImageResponse> {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  const { data } = await api.post<UploadProfileImageResponse>(
+    '/users/me/image',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+
+  return data;
+}
+
+/** 내 정보 수정 */
+export async function updateMyInfo(
+  payload: UpdateMyInfoPayload,
+): Promise<User> {
+  const { data } = await api.put<User>('/users/me', payload);
+  return data;
+}

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -9,32 +9,35 @@
 import Image from 'next/image';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import Input from '@/components/common/Input/Input';
 import Button from '@/components/common/Button';
+import { getMyInfo, updateMyInfo, uploadProfileImage } from '@/api/user';
+import { QUERY_KEYS } from '@/constants/queryKeys';
 
 export default function MyPage() {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const queryClient = useQueryClient();
 
-  const mockMyInfo = {
-    id: 1,
-    email: 'test1@test.com',
-    nickname: 'seungmi',
-    profileImageUrl: null,
-    createdAt: '2026-03-24T04:23:25.506Z',
-    updatedAt: '2026-03-24T04:23:25.506Z',
-  };
+  const { data: myInfo, isLoading } = useQuery({
+    queryKey: QUERY_KEYS.me(),
+    queryFn: getMyInfo,
+  });
 
-  const initialEmail = mockMyInfo.email;
-  const initialNickname = mockMyInfo.nickname;
-  const initialProfileImageUrl = mockMyInfo.profileImageUrl;
+  const initialEmail = myInfo?.email ?? '';
+  const initialNickname = myInfo?.nickname ?? '';
+  const initialProfileImageUrl = myInfo?.profileImageUrl ?? null;
 
-  const [nickname, setNickname] = useState(initialNickname);
-  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
-  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(
-    initialProfileImageUrl,
+  const [nickname, setNickname] = useState<string | undefined>(undefined);
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | undefined>(
+    undefined,
   );
+  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
+
+  const currentNickname = nickname ?? initialNickname;
+  const currentPreviewImageUrl = previewImageUrl ?? initialProfileImageUrl;
 
   // 비밀번호 상태
   const [currentPassword, setCurrentPassword] = useState('');
@@ -44,20 +47,36 @@ export default function MyPage() {
   // 에러 상태
   const [isPasswordMismatch, setIsPasswordMismatch] = useState(false);
 
-  const isNicknameChanged = nickname !== initialNickname;
+  const isNicknameChanged =
+    nickname !== undefined && currentNickname !== initialNickname;
   const isImageChanged = selectedImageFile !== null;
   const isProfileChanged = isNicknameChanged || isImageChanged;
 
   const isPasswordFormValid =
     currentPassword !== '' && newPassword !== '' && confirmPassword !== '';
 
+  const uploadProfileImageMutation = useMutation({
+    mutationFn: uploadProfileImage,
+  });
+
+  const updateMyInfoMutation = useMutation({
+    mutationFn: updateMyInfo,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.me() });
+      alert('프로필이 업데이트되었습니다');
+    },
+    onError: () => {
+      alert('프로필 수정에 실패했습니다');
+    },
+  });
+
   useEffect(() => {
     return () => {
-      if (previewImageUrl && selectedImageFile) {
+      if (previewImageUrl) {
         URL.revokeObjectURL(previewImageUrl);
       }
     };
-  }, [previewImageUrl, selectedImageFile]);
+  }, [previewImageUrl]);
 
   const handleCurrentPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
     setCurrentPassword(e.target.value);
@@ -88,7 +107,7 @@ export default function MyPage() {
     const mockCurrentPassword = '1234'; // TODO: API 연동 시 제거
 
     if (currentPassword !== mockCurrentPassword) {
-      alert('현재 비밀번호가 틀립니다');
+      alert('현재 비밀번호가 틀립니다.');
       return;
     }
 
@@ -127,16 +146,34 @@ export default function MyPage() {
     event.target.value = '';
   };
 
-  const handleProfileSave = () => {
+  const handleProfileSave = async () => {
     if (!isProfileChanged) {
       return;
     }
 
-    console.log({
-      nickname,
-      selectedImageFile,
-    });
+    try {
+      let profileImageUrl = currentPreviewImageUrl ?? null;
+
+      if (selectedImageFile) {
+        const uploadResult =
+          await uploadProfileImageMutation.mutateAsync(selectedImageFile);
+        profileImageUrl = uploadResult.profileImageUrl;
+      }
+
+      await updateMyInfoMutation.mutateAsync({
+        nickname: currentNickname,
+        profileImageUrl,
+      });
+
+      setSelectedImageFile(null);
+    } catch {
+      alert('프로필 저장 중 오류가 발생했습니다.');
+    }
   };
+
+  if (isLoading) {
+    return <div className="p-6">로딩 중...</div>;
+  }
 
   return (
     <div className="flex flex-col p-6">
@@ -170,10 +207,10 @@ export default function MyPage() {
                 className="h-full w-full"
                 aria-label="프로필 이미지 업로드"
               >
-                {previewImageUrl ? (
+                {currentPreviewImageUrl ? (
                   <div className="relative h-full w-full">
                     <Image
-                      src={previewImageUrl}
+                      src={currentPreviewImageUrl}
                       alt="프로필 미리보기"
                       fill
                       className="object-cover"
@@ -198,7 +235,7 @@ export default function MyPage() {
 
               <Input
                 label="닉네임"
-                value={nickname}
+                value={currentNickname}
                 onChange={handleNicknameChange}
                 placeholder="닉네임 입력"
                 maxLength={10}
@@ -249,7 +286,7 @@ export default function MyPage() {
                 isError={isPasswordMismatch}
                 errorMessage={
                   isPasswordMismatch
-                    ? '비밀번호가 일치하지 않습니다'
+                    ? '비밀번호가 일치하지 않습니다.'
                     : undefined
                 }
               />

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -13,7 +13,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import Input from '@/components/common/Input/Input';
 import Button from '@/components/common/Button';
-import { getMyInfo, updateMyInfo, uploadProfileImage } from '@/api/user';
+import {
+  getMyInfo,
+  updateMyInfo,
+  uploadProfileImage,
+  changePassword,
+} from '@/api/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 
 export default function MyPage() {
@@ -36,6 +41,7 @@ export default function MyPage() {
   );
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
 
+  // NOTE: 서버에서 받아온 초기값과 사용자가 수정 중인 값을 분리해서 다루기 위한 값
   const currentNickname = nickname ?? initialNickname;
   const currentPreviewImageUrl = previewImageUrl ?? initialProfileImageUrl;
 
@@ -55,21 +61,32 @@ export default function MyPage() {
   const isPasswordFormValid =
     currentPassword !== '' && newPassword !== '' && confirmPassword !== '';
 
+  // NOTE: 이미지 업로드와 프로필 수정은 요청 흐름이 달라 mutation을 분리했습니다.
   const uploadProfileImageMutation = useMutation({
     mutationFn: uploadProfileImage,
   });
 
+  // NOTE: 수정 성공 후 최신 사용자 정보를 다시 조회하기 위해 캐시를 무효화합니다.
   const updateMyInfoMutation = useMutation({
     mutationFn: updateMyInfo,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.me() });
-      alert('프로필이 업데이트되었습니다');
-    },
-    onError: () => {
-      alert('프로필 수정에 실패했습니다');
+      alert('프로필이 업데이트되었습니다.');
     },
   });
 
+  const changePasswordMutation = useMutation({
+    mutationFn: changePassword,
+    onSuccess: () => {
+      alert('비밀번호가 변경되었습니다.');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setIsPasswordMismatch(false);
+    },
+  });
+
+  // NOTE: 이미지 미리보기용으로 생성한 object URL이 남지 않도록 정리합니다.
   useEffect(() => {
     return () => {
       if (previewImageUrl) {
@@ -100,14 +117,8 @@ export default function MyPage() {
   };
 
   // 변경 버튼 클릭
-  const handlePasswordChange = () => {
-    if (!isPasswordFormValid) return;
-
-    // 현재 비밀번호 검증 (임시)
-    const mockCurrentPassword = '1234'; // TODO: API 연동 시 제거
-
-    if (currentPassword !== mockCurrentPassword) {
-      alert('현재 비밀번호가 틀립니다.');
+  const handlePasswordChange = async () => {
+    if (!isPasswordFormValid) {
       return;
     }
 
@@ -116,12 +127,16 @@ export default function MyPage() {
       return;
     }
 
-    // TODO: 비밀번호 변경 API 연결
-    console.log({
-      currentPassword,
-      newPassword,
-    });
+    try {
+      await changePasswordMutation.mutateAsync({
+        password: currentPassword,
+        newPassword,
+      });
+    } catch {
+      alert('비밀번호 변경에 실패했습니다.');
+    }
   };
+
   const handleNicknameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setNickname(event.target.value);
   };
@@ -166,6 +181,7 @@ export default function MyPage() {
       });
 
       setSelectedImageFile(null);
+      setPreviewImageUrl(undefined);
     } catch {
       alert('프로필 저장 중 오류가 발생했습니다.');
     }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,3 +10,15 @@ export interface ProfileOwner {
   nickname: string;
   id?: number;
 }
+
+/**
+ * 로그인한 유저 정보
+ */
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [X] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- 마이페이지 프로필 섹션 API 연동
  - GET /users/me를 통해 초기 사용자 정보 조회
  - 프로필 이미지 업로드 API 연동
  - 닉네임 및 프로필 이미지 수정 API 연동
  - 수정 성공 시 QUERY_KEYS.me() 캐시 무효화로 최신 데이터 반영
- 마이페이지 비밀번호 변경 API 연동
  - 기존 로컬 검증 로직 유지 (빈 값 체크, 비밀번호 일치 여부)
  - PUT /auth/password API 연결
  - 성공 시 입력값 초기화 및 에러 상태 초기화
- 프로필 이미지 미리보기 처리 개선
  - object URL 생성 후 cleanup 처리 추가
  - 프로필 저장 후 preview 상태 초기화 로직 추가

## 📸 스크린샷 (UI 변경 시 권장)

| 변경 전 | 변경 후 |
| ------- | ------- |
|         |         |

## 🔗 관련 이슈

- Resolves #112 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [X] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [X] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [X] 불필요한 `console.log`나 주석을 지웠나요?
- [] (선택) 리뷰어가 특별히 확인해 주었으면 하는 부분이 있나요?