### PR TITLE
feat, fix: 헤더 프로필 뱃지 색상 일치, 대시보드 생성 모달 연결, 뱃지에 프로필 이미지 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 
 # 개발 확인용 preview 페이지 (로컬 전용)
 src/app/preview/
+
+# 로컬 전용 파일
+src/actions/
+public/images/landing 2/

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -71,6 +71,7 @@ export default function MyPage() {
     mutationFn: updateMyInfo,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.me() });
+      queryClient.invalidateQueries({ queryKey: ['members'] });
       alert('프로필이 업데이트되었습니다.');
     },
   });

--- a/src/components/Modal/DashboardCreateModal.tsx
+++ b/src/components/Modal/DashboardCreateModal.tsx
@@ -12,6 +12,7 @@ interface DashboardCreateModalProps {
   isOpen: boolean;
   onClose: () => void;
   dashboards: Dashboard[];
+  onSuccess?: (newId: number) => void;
 }
 
 function isDuplicateDashboard(
@@ -29,6 +30,7 @@ export default function DashboardCreateModal({
   isOpen,
   onClose,
   dashboards,
+  onSuccess,
 }: DashboardCreateModalProps) {
   const router = useRouter();
   const [dashboardName, setDashboardName] = useState('');
@@ -55,6 +57,7 @@ export default function DashboardCreateModal({
       const createdData = response.data;
 
       if (createdData?.id) {
+        onSuccess?.(createdData.id);
         router.push(`/dashboard/${createdData.id}`);
         router.refresh();
         onClose();

--- a/src/components/common/User/UserProfileImage.tsx
+++ b/src/components/common/User/UserProfileImage.tsx
@@ -14,7 +14,7 @@ import { ProfileOwner } from '@/types/user';
 import Image from 'next/image';
 
 /** 프로필 이미지 없을 때 순서에 따라 순환하는 배경색 */
-const CHIP_COLORS = [
+export const CHIP_COLORS = [
   '#FFC85A',
   '#FDD446',
   '#9DD7ED',

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -24,7 +24,9 @@ import { getDashboard, getMembers, inviteMember } from '@/api/dashboard';
 import { getMe } from '@/api/auth';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { useDashboardStore } from '@/store/useDashboardStore';
-import UserProfileImage from '@/components/common/User/UserProfileImage';
+import UserProfileImage, {
+  CHIP_COLORS,
+} from '@/components/common/User/UserProfileImage';
 import Skeleton from '@/components/common/Skeleton/Skeleton';
 import FormModal from '@/components/Modal/FormModal';
 import ModalOverlay from '@/components/common/ModalBase/ModalOverlay';
@@ -93,6 +95,10 @@ export default function Header() {
   const members = membersData?.members ?? [];
   const visibleMembers = members.slice(0, maxVisibleMembers);
   const extraCount = Math.max(0, members.length - maxVisibleMembers);
+
+  const myMemberIndex = me ? members.findIndex((m) => m.userId === me.id) : -1;
+  const myChipColor =
+    CHIP_COLORS[(myMemberIndex >= 0 ? myMemberIndex : 0) % CHIP_COLORS.length];
 
   const handleManageClick = () => {
     if (dashboardId) {
@@ -276,7 +282,10 @@ export default function Header() {
                 onClick={() => router.push('/mypage')}
                 className="ml-2 md:ml-4 lg:ml-6 flex items-center gap-2 md:gap-3 border-l border-gray-300 pl-2 md:pl-4 lg:pl-6 hover:opacity-80 transition-opacity shrink-0"
               >
-                <div className="flex h-[38px] w-[38px] items-center justify-center rounded-full overflow-hidden bg-[#A3C4A2] text-lg-medium text-white shrink-0">
+                <div
+                  className="flex h-[38px] w-[38px] items-center justify-center rounded-full overflow-hidden text-lg-medium text-white shrink-0"
+                  style={{ backgroundColor: myChipColor }}
+                >
                   {me?.profileImageUrl ? (
                     <Image
                       src={me.profileImageUrl}

--- a/src/components/layout/SideMenu/SideMenu.tsx
+++ b/src/components/layout/SideMenu/SideMenu.tsx
@@ -18,7 +18,11 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import {
+  useQuery,
+  useInfiniteQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import {
   DndContext,
   closestCenter,
@@ -45,6 +49,7 @@ import { cn } from '@/lib/utils';
 import { getDashboards } from '@/api/dashboard';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import type { Dashboard } from '@/types/dashboard';
+import DashboardCreateModal from '@/components/Modal/DashboardCreateModal';
 
 const PAGE_SIZE = 15;
 const MIN_WIDTH = 67;
@@ -351,7 +356,9 @@ function SideMenuSkeleton({ layout }: { layout: LayoutType | null }) {
 
 const SideMenu = () => {
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   /** 인라인 스타일 너비. null이면 CSS 클래스 기반 반응형 유지 */
   const [sidebarWidth, setSidebarWidth] = useState<number | null>(null);
@@ -699,6 +706,7 @@ const SideMenu = () => {
           type="button"
           className="w-5 h-5 flex items-center justify-center text-gray-500 hover:text-gray-700 transition-colors"
           aria-label="대시보드 추가"
+          onClick={() => setIsCreateModalOpen(true)}
         >
           <AddBoxIcon width={20} height={20} />
         </button>
@@ -817,6 +825,28 @@ const SideMenu = () => {
       >
         <div className="absolute right-2 top-0 h-full w-1 hover:bg-brand-violet/30 active:bg-brand-violet/50 transition-colors" />
       </div>
+
+      <DashboardCreateModal
+        isOpen={isCreateModalOpen}
+        onClose={() => {
+          setIsCreateModalOpen(false);
+          queryClient.invalidateQueries({ queryKey: QUERY_KEYS.dashboards() });
+        }}
+        onSuccess={(newId) => {
+          const key = 'dashboard-order-page-1';
+          try {
+            const saved = localStorage.getItem(key);
+            const existing: number[] = saved ? JSON.parse(saved) : [];
+            const next = [newId, ...existing.filter((id) => id !== newId)];
+            localStorage.setItem(key, JSON.stringify(next));
+            setLocalOrderMap((prev) => ({ ...prev, [key]: next }));
+          } catch {
+            /* 시크릿 모드 등 */
+          }
+          setPage(1);
+        }}
+        dashboards={dashboards}
+      />
     </aside>
   );
 };


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

- [x] ✨ 기능 추가
- [ ] 🌻 버그 수정
- [ ] 🔧 리팩토링
- [ ] 🫧 UI 디자인 변경
- [ ] ⚙️ 환경 설정 및 기타

## 📝 작업 내용

- 대시보드 생성 모달 연결 (회색 사각 +버튼)
- 대시보드 헤더 프로필과 멤버 뱃지 색상 일치
- 멤버 뱃지에 프로필 이미지 연동


## 🔗 관련 이슈

- Resolves #134 

## ✅ 체크리스트 (리뷰 요청 전 필수 확인)

- [x] 팀의 코드 컨벤션을 준수했나요? (변수명, 폴더 구조 등)
- [x] 콘솔 에러나 린트(ESLint) 경고가 없는지 확인했나요?
- [x] 불필요한 `console.log`나 주석을 지웠나요?
